### PR TITLE
Fix coveralls

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "release:pos": "yarn document && git add . && git commit --no-verify -m \"fix version\" && git push",
     "document": "node index s -t site -o docs && mv docs/hubi.hubi.html docs/index.html",
     "document:watch": "npm-watch document",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "mkdir .nyc_output && nyc report --reporter=text-lcov | coveralls",
     "test:release": "find src -type f \\( -iname \\*.feature -o -iname \\*.test.js \\)"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "release:pos": "yarn document && git add . && git commit --no-verify -m \"fix version\" && git push",
     "document": "node index s -t site -o docs && mv docs/hubi.hubi.html docs/index.html",
     "document:watch": "npm-watch document",
-    "coveralls": "mkdir .nyc_output && nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "yarn coverage && nyc report --reporter=text-lcov | coveralls",
     "test:release": "find src -type f \\( -iname \\*.feature -o -iname \\*.test.js \\)"
   },
   "dependencies": {


### PR DESCRIPTION
# Proposed changes

Coverall was failing silently when it failed to read the required files from `nyc`. So forcing a coverage will yield the required folder.

## Checklist

- [x] I have reviewed the most recent version of [CONTRIBUTING](CONTRIBUTING.md) to this repository
- [x] I have validated that lint and tests pass locally with my changes
- [x] I have added tests that prove the PR works (if appropriate)
- [x] I have covered at least 50% of the code
- [x] I have added necessary documentation (if appropriate)
- [x] I have merged the last version into my PR (if appropriate)
- [x] I have reviewed the PR and consider it to be small (to make reviewing it easier)
- Select one from the following about your PR, it...
  - [ ] is a non-breaking change (patch)
  - [ ] adds functionality withouth breaking changes (minor)
  - [ ] cause existing functionalities to not work as expected (major)

