### PR TITLE
Fix default message for deprecated tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubi",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Humanitarian ubiquitous language helper",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:integration": "cucumber-js \"src/Domain/UseCases/**/*.feature\"",
     "test:integration:watch": "npm-watch test:integration",
-    "test:unit": "mocha \"src/**/*.test.js\" --colors --sort --bail --recursive --retries 2",
+    "test:unit": "mocha \"src/**/*.test.js\" --colors --sort --bail --recursive",
     "test:unit:watch": "npm-watch test:unit",
     "test:watch": "npm-watch test",
     "coverage": "nyc yarn test",

--- a/src/Domain/Entities/DomainFile/UbiquitousToken.js
+++ b/src/Domain/Entities/DomainFile/UbiquitousToken.js
@@ -3,10 +3,9 @@ const NormalizeName = require('../../Services/NormalizeName')
 const Deprecated = require('../../Objects/Deprecated')
 
 function UbiquitousToken ({ object }) {
-  this.object = object
-  this.name = NormalizeName(object.name)
+  this.object = Object.assign({}, object, new Deprecated(object))
 
-  Object.assign(this, new Deprecated(this, object))
+  this.name = NormalizeName(object.name)
 }
 
 module.exports = UbiquitousToken

--- a/src/Domain/Objects/AttributeParser/AttributeParser.test.js
+++ b/src/Domain/Objects/AttributeParser/AttributeParser.test.js
@@ -76,7 +76,7 @@ describe('AttributeParser', () => {
     })
   })
 
-  context.skip('Deprecation', () => {
+  context('Deprecation', () => {
     const testDeprecation = ({ deprecated }, message, error) => {
       it('Matches the message', () => assert.equal(deprecated.message, message))
 

--- a/src/Domain/Objects/AttributeParser/Attributes/Attribute.js
+++ b/src/Domain/Objects/AttributeParser/Attributes/Attribute.js
@@ -14,7 +14,7 @@ function Attribute (data) {
   this.description = data.description
   this.default = data.default
 
-  Object.assign(this, new Deprecated(this, data.deprecated))
+  Object.assign(this, new Deprecated(data))
 }
 
 Attribute.includes = function includes (...types) {

--- a/src/Domain/Objects/Deprecated/index.js
+++ b/src/Domain/Objects/Deprecated/index.js
@@ -1,11 +1,17 @@
-function Deprecated (object, data) {
-  if (!data) return {}
+function Deprecated ({ name, deprecated }) {
+  if (!deprecated) return {}
 
-  if (typeof data === 'string') return new Deprecated(object, { message: data })
+  if (typeof deprecated === 'string') {
+    const depreciation = {
+      message: deprecated
+    }
+
+    return new Deprecated({ name, deprecated: depreciation })
+  }
 
   this.deprecated = {
-    message: data.message || `"${object.name}" is marked as deprecated`,
-    error: !!data.error
+    message: deprecated.message || `"${name}" is marked as deprecated`,
+    error: !!deprecated.error
   }
 }
 


### PR DESCRIPTION
# Proposed changes

Use a clearer interface to make clear what is important for depreciation, by that it becomes evident that tokens and attributes share at least two attributes (name and deprecated), so they could be used to fix the default message for deprecated tokens.

(The only test is about attributes)

## Relates

* Fixes from #58 

## Checklist

- [x] I have reviewed the most recent version of [CONTRIBUTING](CONTRIBUTING.md) to this repository
- [x] I have validated that lint and tests pass locally with my changes
- [x] I have added tests that prove the PR works (if appropriate)
- [x] I have covered at least 50% of the code
- [x] I have added necessary documentation (if appropriate)
- [x] I have merged the last version into my PR (if appropriate)
- [x] I have reviewed the PR and consider it to be small (to make reviewing it easier)
- Select one from the following about your PR, it...
  - [x] is a non-breaking change (patch)
  - [ ] adds functionality withouth breaking changes (minor)
  - [ ] cause existing functionalities to not work as expected (major)

